### PR TITLE
Minimize resource location/key allocations

### DIFF
--- a/src/main/java/com/supermartijn642/tesseract/manager/TesseractReference.java
+++ b/src/main/java/com/supermartijn642/tesseract/manager/TesseractReference.java
@@ -23,6 +23,7 @@ public class TesseractReference {
 
     private final long index;
     private final String dimension;
+    private final ResourceKey<Level> dimensionKey;
     private final BlockPos pos;
     private final boolean isClientSide;
     private final EnumMap<EnumChannelType,Integer> channels = new EnumMap<>(EnumChannelType.class);
@@ -32,7 +33,8 @@ public class TesseractReference {
 
     TesseractReference(long index, TesseractBlockEntity entity){
         this.index = index;
-        this.dimension = entity.getLevel().dimension().location().toString();
+        this.dimensionKey = entity.getLevel().dimension();
+        this.dimension = this.dimensionKey.location().toString();
         this.pos = entity.getBlockPos();
         this.isClientSide = entity.getLevel().isClientSide;
         for(EnumChannelType type : EnumChannelType.values()){
@@ -45,6 +47,7 @@ public class TesseractReference {
     public TesseractReference(long index, CompoundTag tag, boolean isClientSide){
         this.index = index;
         this.dimension = tag.getString("dim");
+        this.dimensionKey = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(this.dimension));
         this.pos = new BlockPos(tag.getInt("posx"), tag.getInt("posy"), tag.getInt("posz"));
         this.isClientSide = isClientSide;
         for(EnumChannelType type : EnumChannelType.values()){
@@ -64,9 +67,8 @@ public class TesseractReference {
 
     public Level getLevel(){
         if(this.isClientSide)
-            return ClientUtils.getWorld().dimension().location().toString().equals(this.dimension) ? ClientUtils.getWorld() : null;
-        ResourceKey<Level> key = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(this.dimension));
-        return CommonUtils.getLevel(key);
+            return ClientUtils.getWorld().dimension() == this.dimensionKey ? ClientUtils.getWorld() : null;
+        return CommonUtils.getLevel(this.dimensionKey);
     }
 
     public BlockPos getPos(){
@@ -88,7 +90,7 @@ public class TesseractReference {
      */
     public boolean canBeAccessed(){
         Level level = this.getLevel();
-        return level != null && this.getLevel().isLoaded(this.pos) && this.isValid();
+        return level != null && level.isLoaded(this.pos) && this.isValid();
     }
 
     public TesseractBlockEntity getTesseract(){


### PR DESCRIPTION
Noticed an extreme amount of allocations coming from this in a singleplayer world; these keys can be cached once in the `TesseractReference` and then reused.